### PR TITLE
Allow methylPipe to be used on non-UCSC genomes

### DIFF
--- a/R/BSdataSet-methods.R
+++ b/R/BSdataSet-methods.R
@@ -545,7 +545,7 @@ setMethod('methstats', 'BSdataSet', function(object, chrom, mcClass='mCG', minC=
   clust_mat <- t(mc_table)
   dist_mat <- dist(clust_mat, method = "euclidean")
   x <- hclust(dist_mat)
-  dev.new()
+  if(names(dev.set()) != "pdf") dev.new() # disable dev.new() to work with pdf()
   plot(x, main="Methylation Clustering", xlab="Samples")
   return(statistics_results)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # methylPipe for custom genomes
-This is a fork of the methylPipe Bioconductor package (https://github.com/Bioconductor-mirror/methylPipe)
-Some of the functions in the original package is not compatible with non-UCSC genomes, as a result it is not most suitable for custome genomes. I have make some changes to fix this.
+This is a fork of the methylPipe Bioconductor package (https://github.com/Bioconductor-mirror/methylPipe).
+Some of the functions in the original package is not compatible with non-UCSC genomes, as a result it is not most suitable for custom genomes. I have made the following changes to fix this.
 
 ### Changes
 ##### R/BSdataSet-methods.R

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# methylPipe for custom genomes
+This is a fork of the methylPipe Bioconductor package (https://github.com/Bioconductor-mirror/methylPipe)
+Some of the functions in the original package is not compatible with non-UCSC genomes, as a result it is not most suitable for custome genomes. I have make some changes to fix this.
+
+### Changes
+##### R/BSdataSet-methods.R
+1. methstats()
+* line 548 - disable dev.new() when using pdf()
+
+##### R/Allfunctions.R
+1. BSprepare()
+* line 187 - add "addchr" switch
+* line 226 - check "addchr"
+
+2. plotMeth()
+* line 825 - add "ucscOrg" switch and band dataframe required if ucscOrg=FALSE
+* line 886-894 - use custom band dataframe to create Ideogram track with custom genome
+

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Some of the functions in the original package is not compatible with non-UCSC ge
 ### Changes
 ##### R/BSdataSet-methods.R
 1. methstats()
-* line 548 - disable dev.new() when using pdf()
+  * line 548 - disable dev.new() when using pdf()
 
 ##### R/Allfunctions.R
 1. BSprepare()
-* line 187 - add "addchr" switch
-* line 226 - check "addchr"
+  * line 187 - add "addchr" switch
+  * line 226 - check "addchr"
 
 2. plotMeth()
-* line 825 - add "ucscOrg" switch and band dataframe required if ucscOrg=FALSE
-* line 886-894 - use custom band dataframe to create Ideogram track with custom genome
+  * line 825 - add "ucscOrg" switch and band dataframe required if ucscOrg=FALSE
+  * line 886-894 - use custom band dataframe to create Ideogram track with custom genome
 

--- a/man/BSprepare.Rd
+++ b/man/BSprepare.Rd
@@ -7,13 +7,14 @@
   object.
 }
 \usage{
-BSprepare(files_location, output_folder, tabixPath, bc=1.5/100)
+BSprepare(files_location, output_folder, tabixPath, bc=1.5/100, addchr=TRUE)
 }
 \arguments{
   \item{files_location}{character; the path to the files}
   \item{output_folder}{character; the path to the output files}
   \item{tabixPath}{character; the path to the Tabix application folder}
   \item{bc}{numeric; combined bisulfite conversion and sequencing error rate}
+  \item{addchr}{logical; whether to append "chr" to the chromosome name}
 }
 \details{This function can be used to convert tabular files containing
   DNA-methylation base-resolution data so that they can be used to

--- a/man/plotMeth.Rd
+++ b/man/plotMeth.Rd
@@ -6,7 +6,7 @@
 }
 \usage{
 plotMeth(grl=NULL, colors=NULL, datatype=NULL, yLim, brmeth=NULL, mcContext="CG", annodata=NULL, 
-transcriptDB, chr, start, end, org)
+transcriptDB, chr, start, end, org, ucscOrg=TRUE, bands=NULL)
 }
 \arguments{
   \item{grl}{An object of class \link{GElist} or a potentially mixed \link{list} of \link{GRanges} or \link{GEcollection} objects}
@@ -22,6 +22,8 @@ transcriptDB, chr, start, end, org)
   \item{start}{numeric; chromosome start}
   \item{end}{numeric; chromosome end}
   \item{org}{BSgenome; an object of class BSgenome}
+  \item{ucscOrg}{logical; whether the BSgenome is for a valid UCSC genome}
+  \item{bands}{An object of class data frame}
 }
 \details{
 This function can be used to display for one genomic region (genome-browser like) DNA methylation data together with other omics data or static annotation info. The genomic region is indicated by chr, start and end. Specifically, grl is used to display binned high- or low-resolution data, while brmeth is used to point to (unbinned) base-resolution data. Each component of grl can either be a GEcollection or a GRanges.


### PR DESCRIPTION
I have made some changes to the code so that the package can be used to analyse custom genomes